### PR TITLE
correctly recognize entity names use slashTags format

### DIFF
--- a/ner/client.py
+++ b/ner/client.py
@@ -20,7 +20,7 @@ from .utils import (
 
 
 #regex patterns for various tagging options for entity parsing
-SLASHTAGS_EPATTERN  = re.compile(r'(.+?)/([A-Z]+?)\s*')
+SLASHTAGS_EPATTERN  = re.compile(r'(.+?)/([A-Z]+)?\s*')
 XML_EPATTERN        = re.compile(r'<wi num=".+?" entity="(.+?)">(.+?)</wi>')
 INLINEXML_EPATTERN  = re.compile(r'<([A-Z]+?)>(.+?)</\1>')
 


### PR DESCRIPTION
the slashtags regex was previously matching only the first letter after /. For example it was matching only the "/O" part of "/ORGANIZATION"

before:
In [4]: tagger.get_entities("I live near Disney World")
Out[4]: {'O': ['I live near Disney RGANIZATION World']}

with this change:
In [8]: tagger.get_entities("I live near Disney World")
Out[8]: {'O': ['I live near'], 'ORGANIZATION': ['Disney World']}
