### PR TITLE
Adds email to elimiate register warning.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ specs = {
     'long_description' : description,
     'url' : 'http://github.com/dat/pyner',
     'author' : 'Dat Hoang',
+    'author_email' : 'dat.hoang@gmail.com',
     'keywords' : ['ner', 'stanford named entity recognizer', 'stanford named entity tagger'],
     'license' : 'BSD',
     'packages' : ['ner'],


### PR DESCRIPTION
I was gonna get Pyner and realized it's not available in Pypi. I was looking if it is shippable and ran into an warning where it was complaining about missing `author_email`. Do you mind if I push Pyner to Pypi? Or could you please push it? It seems to be good to go. 

Thanks!!
