### PR TITLE
Fixing second socet exception.

### DIFF
--- a/ner/utils.py
+++ b/ner/utils.py
@@ -20,12 +20,11 @@ def tcpip4_socket(host, port):
     finally:
         try:
             s.shutdown(socket.SHUT_RDWR)
+            s.close()
         except socket.error:
             pass
         except OSError:
             pass
-        finally:
-            s.close()
 
 @contextmanager
 def http_connection(host, port):


### PR DESCRIPTION
The socket may get closed due to an error, in which case the close() in
the finally clause raises a second exception.
