### PR TITLE
changed the way that SocketNER retrieves data from the socket server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
 python: 
- - "2.7
+  - "2.7
 script: python run_tests
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: python
 python: 
  - "2.7
 script: python run_tests
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
 python: 
-  - "2.7
+  - "2.7"
 script: python run_tests
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: python
+python: 
+ - "2.7
+script: python run_tests


### PR DESCRIPTION
`SocketNER.tag_text` would now retrieve data in chunks of size 4092, and bail after a two-second timeout. May address issue #14 and issue #11. It will probably desirable to make the timeout configurable (either in the `SocketNER` constructor, or as a kwarg in `tag_text`), but I didn't quite feel comfortable messing with the API.
