### PR TITLE
docs: fix simple typo, strig -> string

### DIFF
--- a/ner/client.py
+++ b/ner/client.py
@@ -144,7 +144,7 @@ class HttpNER(NER):
     def tag_text(self, text):
         """Tag the text with proper named entities token-by-token.
 
-        :param text: raw text strig to tag
+        :param text: raw text string to tag
         :returns: tagged text in given output format
         """
         for s in ('\f', '\n', '\r', '\t', '\v'): #strip whitespaces


### PR DESCRIPTION
There is a small typo in ner/client.py.

Should read `string` rather than `strig`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md